### PR TITLE
enforce 1 move minimum

### DIFF
--- a/src/game/board.tsx
+++ b/src/game/board.tsx
@@ -969,7 +969,9 @@ export function GHQBoard({
             <div className="flex gap-1 justify-center items-center">
               {ctx.currentPlayer === playerID || !G.isOnline ? (
                 <>
-                  <SkipButton skip={() => moves.Skip()} />
+                  {!!ctx.numMoves && ctx.numMoves > 0 && (
+                    <SkipButton skip={() => moves.Skip()} />
+                  )}
                   {G.drawOfferedBy && G.drawOfferedBy !== ctx.currentPlayer ? (
                     <AcceptDrawButton draw={() => moves.AcceptDraw()} />
                   ) : (

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -338,8 +338,11 @@ const ChangeOrientation: Move<GHQState> = (
   });
 };
 
-const Skip: Move<GHQState> = ({ G, ctx, events }) => {
-  events.endTurn();
+const Skip: Move<GHQState> = {
+  noLimit: true,
+  move: ({ events }) => {
+    events.endTurn();
+  },
 };
 
 const Resign: Move<GHQState> = ({ G, ctx, events }) => {
@@ -485,6 +488,7 @@ export const GHQGame: Game<GHQState> = {
     };
   },
   turn: {
+    minMoves: 1,
     maxMoves: 3,
     onBegin: ({ ctx, G, random, log, ...plugins }) => {
       G.lastPlayerMoves = G.thisTurnMoves;


### PR DESCRIPTION
Enforced at the engine and UI levels

- Skip no longer counts towards `numMoves`
- `minMoves` is 1
- UI hides the `Skip` button until `numMoves > 0`

There's a discussion around whether to hide the button or keep it visible, but display a toast message when they try to click it, but it's simpler to hide for now, and I think people will get it