### PR TITLE
Click drag hold repositions

### DIFF
--- a/src/components/LongPressDiv.tsx
+++ b/src/components/LongPressDiv.tsx
@@ -1,0 +1,56 @@
+import React, { PropsWithChildren, useCallback, useState } from "react";
+
+function LongPressTD(
+  props: PropsWithChildren<
+    React.TdHTMLAttributes<HTMLTableCellElement> & {
+      durationMS: number;
+      onLongPress?: () => void;
+    }
+  >
+) {
+  const { durationMS, onLongPress, ...otherProps } = props;
+
+  const [timer, setTimer] = useState<NodeJS.Timeout | null | "fired">(null);
+
+  const runAndClear = useCallback(() => {
+    setTimer("fired");
+    if (onLongPress) {
+      onLongPress();
+    }
+  }, [setTimer]);
+
+  // Start the timer when the mouse/touch is down
+  const startPressTimer = () => {
+    const newTimer = setTimeout(runAndClear, durationMS);
+    setTimer(newTimer);
+  };
+
+  // Clear the timer when the mouse/touch is released
+  const cancelPressTimer = (event: any) => {
+    if (timer === "fired") {
+      // do nothing
+    } else if (timer) {
+      clearTimeout(timer);
+      setTimer(null);
+      props.onClick && props.onClick(event);
+    }
+  };
+
+  return (
+    <td
+      className="bg-green-50"
+      onMouseDown={startPressTimer}
+      onMouseUp={cancelPressTimer}
+      onMouseLeave={cancelPressTimer}
+      onTouchStart={startPressTimer}
+      onTouchEnd={cancelPressTimer}
+      {...otherProps}
+      // override empty since we're calling it above
+      onClick={undefined}
+    >
+      {props.children}
+    </td>
+  );
+}
+
+export default LongPressTD;

--- a/src/components/LongPressDiv.tsx
+++ b/src/components/LongPressDiv.tsx
@@ -17,7 +17,7 @@ function LongPressTD(
     if (onLongPress) {
       onLongPress();
     }
-  }, [setTimer]);
+  }, [setTimer, onLongPress]);
 
   // Start the timer when the mouse/touch is down
   const startPressTimer = () => {

--- a/src/game/board-state.ts
+++ b/src/game/board-state.ts
@@ -152,13 +152,8 @@ export const turnStateMachine = createMachine(
           },
           AIM_ACTIVE_PIECE: {
             guard: ({ context, event }) => {
-              console.log("GOT HERE");
-              console.log("AIMING", context, event);
               const isArtillery =
                 typeof Units[event.piece!.type].artilleryRange !== "undefined";
-
-              console.log("HERE", isArtillery);
-              console.log("HERE 2", context.canReorient, event.at);
 
               if (
                 isArtillery &&
@@ -182,26 +177,18 @@ export const turnStateMachine = createMachine(
               );
             },
             actions: assign(({ context, event }) => {
-              const restrictToReorientation =
-                context.canReorient &&
-                context.canReorient[0] === event.at[0] &&
-                context.canReorient[1] === event.at[1];
-
               return {
                 selectedPiece: {
                   piece: event.piece,
                   at: event.at,
                 },
-                allowedMoves: restrictToReorientation
-                  ? []
-                  : movesForActivePiece(event.at, event.currentBoard),
+                allowedMoves: [],
               };
             }),
             target: "activePieceSelected.selectOrientation",
           },
           SELECT_ACTIVE_PIECE: {
             guard: ({ context, event }) => {
-              console.log("world", context);
               return (
                 // can't have been moved before
                 !context.disabledPieces?.some(
@@ -301,7 +288,6 @@ export const turnStateMachine = createMachine(
             on: {
               CHANGE_ORIENTATION: {
                 guard: ({ context, event }) => {
-                  console.log("I AM HERE ", context, event);
                   // is artillery
                   return (
                     typeof Units[context.selectedPiece!.piece.type]
@@ -309,7 +295,7 @@ export const turnStateMachine = createMachine(
                   );
                 },
                 actions: [
-                  "moveAndOrient",
+                  "changeOrientation",
                   assign(({ event, context }) => ({
                     canReorient: context.stagedMove
                       ? context.stagedMove
@@ -375,7 +361,6 @@ export const turnStateMachine = createMachine(
           },
           SELECT_SQUARE: {
             guard: ({ context, event }) => {
-              console.log("WEIRD HERE");
               return !!context.allowedMoves?.some(
                 (placement) =>
                   placement[0] === event.at[0] && placement[1] === event.at[1]

--- a/src/game/board-state.ts
+++ b/src/game/board-state.ts
@@ -276,40 +276,68 @@ export const turnStateMachine = createMachine(
                       canReorient: event.at,
                       disabledPieces: [...context.disabledPieces, event.at!],
                     })),
-                    "moveAndOrient",
+                    // "moveAndOrient",
                   ],
 
-                  target: "#turn-machine.ready",
+                  target: "selectOrientation",
                 },
               ],
             },
           },
           selectOrientation: {
             on: {
-              CHANGE_ORIENTATION: {
-                guard: ({ context, event }) => {
-                  // is artillery
-                  return (
-                    typeof Units[context.selectedPiece!.piece.type]
-                      .artilleryRange !== "undefined"
-                  );
-                },
-                actions: [
-                  "changeOrientation",
-                  assign(({ event, context }) => ({
-                    canReorient: context.stagedMove
-                      ? context.stagedMove
-                      : context.selectedPiece!.at,
-                    disabledPieces: [
-                      ...context.disabledPieces,
-                      context.stagedMove
+              CHANGE_ORIENTATION: [
+                {
+                  guard: ({ context, event }) => {
+                    // is artillery, and has not been moved
+                    return (
+                      !context.stagedMove &&
+                      typeof Units[context.selectedPiece!.piece.type]
+                        .artilleryRange !== "undefined"
+                    );
+                  },
+                  actions: [
+                    "changeOrientation",
+                    assign(({ event, context }) => ({
+                      canReorient: context.stagedMove
                         ? context.stagedMove
                         : context.selectedPiece!.at,
-                    ],
-                  })),
-                ],
-                target: "#turn-machine.ready",
-              },
+                      disabledPieces: [
+                        ...context.disabledPieces,
+                        context.stagedMove
+                          ? context.stagedMove
+                          : context.selectedPiece!.at,
+                      ],
+                    })),
+                  ],
+                  target: "#turn-machine.ready",
+                },
+                {
+                  guard: ({ context, event }) => {
+                    // is artillery
+                    return (
+                      !!context.stagedMove &&
+                      typeof Units[context.selectedPiece!.piece.type]
+                        .artilleryRange !== "undefined"
+                    );
+                  },
+                  actions: [
+                    "moveAndOrient",
+                    assign(({ event, context }) => ({
+                      canReorient: context.stagedMove
+                        ? context.stagedMove
+                        : context.selectedPiece!.at,
+                      disabledPieces: [
+                        ...context.disabledPieces,
+                        context.stagedMove
+                          ? context.stagedMove
+                          : context.selectedPiece!.at,
+                      ],
+                    })),
+                  ],
+                  target: "#turn-machine.ready",
+                },
+              ],
             },
           },
         },

--- a/src/game/board.tsx
+++ b/src/game/board.tsx
@@ -127,6 +127,7 @@ export function GHQBoard({
           const lastMove = G.thisTurnMoves[G.thisTurnMoves.length - 1];
 
           if (
+            lastMove &&
             context.canReorient &&
             "orientation" in event &&
             lastMove.name === "MoveAndOrient" &&
@@ -646,6 +647,7 @@ export function GHQBoard({
               key={colIndex}
               className={classNames(
                 "relative",
+                "select-none",
                 bombardmentClass,
                 {
                   ["cursor-pointer"]:
@@ -775,16 +777,16 @@ export function GHQBoard({
                     height={pieceSize * 0.7}
                     className="select-none"
                     draggable="false"
-                    style={{
-                      transform: state.context.selectedPiece.piece.orientation
-                        ? isPrimaryPlayer("1")
-                          ? `rotate(${
-                              180 -
-                              state.context.selectedPiece.piece.orientation
-                            }deg)`
-                          : `rotate(${state.context.selectedPiece.piece.orientation}deg)`
-                        : `rotate(${add180 ? 180 : 0}deg)`,
-                    }}
+                    // style={{
+                    //   transform: state.context.selectedPiece.piece.orientation
+                    //     ? isPrimaryPlayer("1")
+                    //       ? `rotate(${
+                    //           180 -
+                    //           state.context.selectedPiece.piece.orientation
+                    //         }deg)`
+                    //       : `rotate(${state.context.selectedPiece.piece.orientation}deg)`
+                    //     : `rotate(${add180 ? 180 : 0}deg)`,
+                    // }}
                     alt={
                       Units[state.context.selectedPiece.piece.type]
                         .imagePathPrefix

--- a/src/game/board.tsx
+++ b/src/game/board.tsx
@@ -139,10 +139,7 @@ export function GHQBoard({
               JSON.stringify(lastMove.args[0]) ===
               JSON.stringify(lastMove.args[1])
             ) {
-              moves.ChangeOrientation(
-                context.selectedPiece!.at,
-                event.orientation
-              );
+              moves.ChangeOrientation(lastMove.args[0], event.orientation);
             } else {
               // aim and reposition
               moves.MoveAndOrient(
@@ -179,8 +176,6 @@ export function GHQBoard({
       },
     })
   );
-
-  console.log(JSON.stringify(state?.value));
 
   const renderBoard = ctx.gameover
     ? G.board
@@ -620,7 +615,6 @@ export function GHQBoard({
             <LongPressTD
               durationMS={350}
               onLongPress={() => {
-                console.log("GOT A ONG PRESS");
                 // @todo aidan seems like this is retained weirdly between renders
                 if (!state.matches("selectEnemyToCapture") && square) {
                   send({

--- a/src/game/board.tsx
+++ b/src/game/board.tsx
@@ -170,7 +170,9 @@ export function GHQBoard({
             moves.MoveAndOrient(
               context.selectedPiece!.at,
               context.stagedMove,
-              context.selectedPiece!.piece.orientation
+              "orientation" in event
+                ? event.orientation
+                : context.selectedPiece!.piece.orientation
             );
           }
         },
@@ -318,7 +320,20 @@ export function GHQBoard({
     }
 
     const aiming = state.matches("activePieceSelected.selectOrientation");
-    if (aiming && state.context.selectedPiece) {
+
+    if (aiming && state.context.stagedMove) {
+      const [x, y] = state.context.stagedMove!;
+      annotate[`${x},${y}`] = {
+        ...annotate[`${x},${y}`],
+        showAim: true,
+        hidePiece: true,
+      };
+      const [fromX, fromY] = state.context.selectedPiece!.at;
+      annotate[`${fromX},${fromY}`] = {
+        ...annotate[`${fromX},${fromY}`],
+        hidePiece: true,
+      };
+    } else if (aiming && state.context.selectedPiece) {
       const [x, y] = state.context.selectedPiece.at;
       annotate[`${x},${y}`] = {
         ...annotate[`${x},${y}`],
@@ -777,16 +792,6 @@ export function GHQBoard({
                     height={pieceSize * 0.7}
                     className="select-none"
                     draggable="false"
-                    // style={{
-                    //   transform: state.context.selectedPiece.piece.orientation
-                    //     ? isPrimaryPlayer("1")
-                    //       ? `rotate(${
-                    //           180 -
-                    //           state.context.selectedPiece.piece.orientation
-                    //         }deg)`
-                    //       : `rotate(${state.context.selectedPiece.piece.orientation}deg)`
-                    //     : `rotate(${add180 ? 180 : 0}deg)`,
-                    // }}
                     alt={
                       Units[state.context.selectedPiece.piece.type]
                         .imagePathPrefix

--- a/src/game/select-orientation.tsx
+++ b/src/game/select-orientation.tsx
@@ -66,29 +66,19 @@ export function SelectOrientation(
     }, [stagedOrientation, props.onChange])
   );
 
-  const angles: { [key: string]: Orientation } = {
-    topLeft: asBlue ? 135 : 315,
-    top: asBlue ? 180 : 0,
-    topRight: asBlue ? 225 : 45,
-    left: asBlue ? 90 : 270,
-    right: asBlue ? 270 : 90,
-    bottomLeft: asBlue ? 45 : 225,
-    bottom: asBlue ? 0 : 180,
-    bottomRight: asBlue ? 315 : 135,
-  };
-
   return (
     <div
       // @ts-ignore
       ref={ref}
       className={classNames(
-        "top-0 absolute overflow-hidden opacity-80 flex items-center justify-center",
+        "top-0 absolute overflow-hidden opacity-80 flex items-center justify-center select-none",
         color
       )}
       style={{ width: props.squareSize, height: props.squareSize }}
     >
       <div
-        className=""
+        className="select-none"
+        key={stagedOrientation}
         style={{
           transform: `rotate(${
             (stagedOrientation + (asBlue ? -180 : 0) + 360) % 360
@@ -142,10 +132,10 @@ function useAnyClick(handler: (event: MouseEvent) => void) {
       handler(event);
     };
 
-    document.addEventListener("click", handleClick);
+    document.addEventListener("mouseup", handleClick);
 
     return () => {
-      document.removeEventListener("click", handleClick);
+      document.removeEventListener("mouseup", handleClick);
     };
   }, [handler]);
 }

--- a/src/game/select-orientation.tsx
+++ b/src/game/select-orientation.tsx
@@ -44,8 +44,6 @@ export function SelectOrientation(
     };
     const orientation = getClosestOrientation((angle as number) - 45 / 2);
 
-    // console.log(orientation);
-
     if (asBlue) {
       if (orientation === 0) setStagedOrientation(180);
       else if (orientation === 45) setStagedOrientation(225);
@@ -84,106 +82,20 @@ export function SelectOrientation(
       // @ts-ignore
       ref={ref}
       className={classNames(
-        "top-0 absolute overflow-hidden opacity-80 flex flex-col",
+        "top-0 absolute overflow-hidden opacity-80 flex items-center justify-center",
         color
       )}
       style={{ width: props.squareSize, height: props.squareSize }}
     >
-      <div className="grid grid-cols-7 gap-2 w-full">
-        <div
-          className="col-span-2 hover:bg-amber-500  bg-slate-400 -rotate-45"
-          onMouseOver={() => setStagedOrientation(angles.topLeft)}
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onChange(angles.topLeft);
-          }}
-        >
-          ▲
-        </div>
-        <div
-          className="col-span-3  hover:bg-amber-500 bg-slate-400"
-          onMouseOver={() => setStagedOrientation(angles.top)}
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onChange(angles.top);
-          }}
-        >
-          ▲
-        </div>
-        <div
-          className="col-span-2 hover:bg-amber-500  bg-slate-400 rotate-45"
-          onMouseOver={() => setStagedOrientation(angles.topRight)}
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onChange(angles.topRight);
-          }}
-        >
-          ▲
-        </div>
-      </div>
-      <div className="grid grid-cols-7 flex-1 items-center ">
-        <div
-          className="col-span-2 hover:bg-amber-500  bg-slate-400 -rotate-90 "
-          onMouseOver={() => setStagedOrientation(angles.left)}
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onChange(angles.left);
-          }}
-        >
-          ▲
-        </div>
-        <div
-          className="col-span-3"
-          style={{
-            transform: `rotate(${
-              (stagedOrientation + (asBlue ? -180 : 0) + 360) % 360
-            }deg)`,
-          }}
-        >
-          {props.children}
-        </div>
-        <div
-          className="col-span-2 hover:bg-amber-500  bg-slate-400 rotate-90"
-          onMouseOver={() => setStagedOrientation(angles.right)}
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onChange(angles.right);
-          }}
-        >
-          ▲
-        </div>
-      </div>
-      <div className="grid grid-cols-7 gap-2 ">
-        <div
-          className="col-span-2 hover:bg-amber-500  bg-slate-400 rotate-[-135deg]"
-          onMouseOver={() => setStagedOrientation(angles.bottomLeft)}
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onChange(angles.bottomLeft);
-          }}
-        >
-          ▲
-        </div>
-        <div
-          className="col-span-3  hover:bg-amber-500 bg-slate-400 rotate-180"
-          onMouseOver={() => setStagedOrientation(angles.bottom)}
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onChange(angles.bottom);
-          }}
-        >
-          ▲
-        </div>
-        <div
-          className="col-span-2 hover:bg-amber-500  bg-slate-400 rotate-[135deg]"
-          onMouseOver={() => setStagedOrientation(angles.bottomRight)}
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onChange(angles.bottomRight);
-          }}
-        >
-          ▲
-        </div>
+      <div
+        className=""
+        style={{
+          transform: `rotate(${
+            (stagedOrientation + (asBlue ? -180 : 0) + 360) % 360
+          }deg)`,
+        }}
+      >
+        {props.children}
       </div>
     </div>
   );


### PR DESCRIPTION
Reorient your artillery pieces by clicking and dragging. 

Notes: 
1. You can reorient the same piece a few times. We reconcile change orientation moves w/ recent move and orient moves. Until you move a different piece, you can always reorient. 
2. There was a bug where tanks would face the wrong way after the 1st turn when you moused around the center of their current square

TODOs: 
[ ]  make this work with tapdown and tapup events for mobile 
[x] if last move is an artillery, automatically go into change orientation mode and don't write move to log until an orientation has been confirmed.   


https://github.com/user-attachments/assets/825d7e46-9a25-4361-977a-7d7629f9cb6f

