### PR TITLE
Improve skip logic and randomness

### DIFF
--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -15,8 +15,18 @@ export const ai: Game<GHQState>["ai"] = {
       currentPlayerTurn: ctx.currentPlayer === "0" ? "RED" : "BLUE",
       thisTurnMoves: G.thisTurnMoves,
     });
-    return allowedMoves.map(({ name, args }) => ({ move: name, args }));
+
+     // Ensure the AI makes exactly 3 moves
+    const movesToMake = allowedMoves.slice(0, 3);
+
+    // If there are fewer than 3 moves, pad with "Skip" moves
+    while (movesToMake.length < 3) {
+      movesToMake.push({ name: "Skip", args: [] });
+    }
+  
+    return movesToMake.map(({ name, args }) => ({ move: name, args }));
   },
+  
   objectives: () => {
     let lastEval = 0;
 

--- a/src/game/board-moves.ts
+++ b/src/game/board-moves.ts
@@ -47,7 +47,7 @@ export function getAllowedMoves({
   blueReserve: ReserveFleet;
   currentPlayerTurn: Player;
 }): AllowedMove[] {
-  const allMoves: AllowedMove[] = [{ name: "Skip", args: [] }];
+  const allMoves: AllowedMove[] = [];
 
   const thisTurnMoveCoordinates = new Set(
     coordsForThisTurnMoves(thisTurnMoves).map(
@@ -139,7 +139,18 @@ export function getAllowedMoves({
     }
   }
 
+  // Shuffle the moves to randomize the order of the moves
+  shuffleArray(allMoves);
+
   return allMoves;
+}
+
+// Simple Fisher-Yates shuffle algorithm
+function shuffleArray<T>(array: T[]): void {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]]; // Swap elements
+  }
 }
 
 function getPlayerPieces(


### PR DESCRIPTION
1. Rather than prepopulating "Skip" in board-moves.ts, make it an empty array.
2. In ai.ts, ensure there are 3 moves, and pad "skip" if there aren't enough moves.
3. When adding potential board moves to iterate through, shuffle them up so AI doesn't make the same beginning moves on low iterations.