### PR TITLE
tank rotation preview removes prev bombarded squares

### DIFF
--- a/src/components/board/Square.tsx
+++ b/src/components/board/Square.tsx
@@ -13,7 +13,7 @@ import {
   Units,
 } from "@/game/engine";
 import classNames from "classnames";
-import { Bombarded } from "@/game/move-logic";
+import { Bombarded, bombardedSquares } from "@/game/move-logic";
 import { Crosshair } from "lucide-react";
 import {
   isBombardedBy,
@@ -96,14 +96,20 @@ export function getSquareState({
   )?.piece;
   const { shouldAnimateTo } = getAnimation(coord, mostRecentMove);
   const engagedOrientation = getEngagedOrientation(coord, boardEngagements);
+  const { isRedBombarded, isBlueBombarded } = getBombardStatus(
+    board,
+    coord,
+    userActionState,
+    bombarded
+  );
 
   return {
     rowIndex,
     colIndex,
     square,
     stagedSquare,
-    isRedBombarded: bombarded[`${rowIndex},${colIndex}`]?.RED ?? false,
-    isBlueBombarded: bombarded[`${rowIndex},${colIndex}`]?.BLUE ?? false,
+    isRedBombarded,
+    isBlueBombarded,
     isSelected,
     showTarget: false,
     wasRecentlyCapturedPiece,
@@ -523,4 +529,29 @@ function getEngagedOrientation(
     engagedOrientation = getOrientationBetween(coord, engagedCoord);
   }
   return engagedOrientation;
+}
+
+function getBombardStatus(
+  board: Board,
+  coord: Coordinate,
+  userActionState: UserActionState | null,
+  bombarded: Bombarded
+) {
+  if (!userActionState?.chosenMoves) {
+    return {
+      isRedBombarded: bombarded[`${coord[0]},${coord[1]}`]?.RED ?? false,
+      isBlueBombarded: bombarded[`${coord[0]},${coord[1]}`]?.BLUE ?? false,
+    };
+  }
+
+  const updatedBoard = JSON.parse(JSON.stringify(board));
+  const originPiece = userActionState?.selectedPiece;
+  if (originPiece) {
+    updatedBoard[originPiece.coordinate[0]][originPiece.coordinate[1]] = null;
+  }
+  const updatedBombarded = bombardedSquares(updatedBoard);
+  return {
+    isRedBombarded: updatedBombarded[`${coord[0]},${coord[1]}`]?.RED ?? false,
+    isBlueBombarded: updatedBombarded[`${coord[0]},${coord[1]}`]?.BLUE ?? false,
+  };
 }


### PR DESCRIPTION
fixes #175

### Before (previous bombarded squares still show)

<img width="396" alt="Screenshot 2025-01-25 at 11 26 34 AM" src="https://github.com/user-attachments/assets/e5ee4c55-77c1-4dbd-bfa0-566d28c477c0" />


### After (previous bombarded squares are hidden)
<img width="394" alt="Screenshot 2025-01-25 at 11 26 44 AM" src="https://github.com/user-attachments/assets/fc2bc482-ef27-4e16-a0c4-41cd9e5218ca" />

