### PR TITLE
fix: only infantry are subject to  zones of control

### DIFF
--- a/src/game/move-logic.ts
+++ b/src/game/move-logic.ts
@@ -1,4 +1,10 @@
-import { Coordinate, GHQState, Player, Units } from "@/game/engine";
+import {
+  Coordinate,
+  GHQState,
+  NonNullSquare,
+  Player,
+  Units,
+} from "@/game/engine";
 import { getOpponent } from "./board-moves";
 import { PlayerPiece } from "./board-moves";
 import { isInfantry } from "./capture-logic";
@@ -58,6 +64,7 @@ export function movesForActivePieceV2(
 
   return getMoves(
     coordinate,
+    piece,
     unitType.mobility,
     board,
     allowedSquares,
@@ -67,6 +74,7 @@ export function movesForActivePieceV2(
 
 function getMoves(
   coordinate: Coordinate,
+  movingPiece: NonNullSquare,
   mobility: 1 | 2,
   board: GHQState["board"],
   allowedSquares: Record<string, boolean>,
@@ -96,6 +104,7 @@ function getMoves(
       // must not have a piece and must be an allowed square (not bombarded or adjacent to enemy infantry)
       if (!piece && allowedSquares[`${newX},${newY}`]) {
         if (
+          isInfantry(movingPiece) &&
           squaresWithAdjacentEnemyInfantry[
             `${coordinate[0]},${coordinate[1]}`
           ] &&

--- a/src/game/tests/move-logic.test.ts
+++ b/src/game/tests/move-logic.test.ts
@@ -22,6 +22,7 @@ const O = true; // square that can be moved to
 const Q: Square = { type: "HQ", player: "RED" };
 const I: Square = { type: "INFANTRY", player: "RED" };
 const F: Square = { type: "ARMORED_INFANTRY", player: "RED" };
+const R: Square = { type: "ARTILLERY", player: "RED", orientation: 180 };
 
 // Blue pieces (indicated by lowercase)
 const q: Square = { type: "HQ", player: "BLUE" };
@@ -646,6 +647,38 @@ describe("computing allowed moves", () => {
         [_, _, _, _, _, _, _, _],
       ],
       [2, 0]
+    );
+  });
+
+  it("HQ should not be affected by a zone of control.", () => {
+    expectMoves(
+      [
+        [_, _, _, _, _, _, _, _],
+        [_, _, _, _, _, _, _, _],
+        [_, _, _, _, _, _, _, _],
+        [_, _, _, _, _, _, _, _],
+        [_, _, _, _, _, _, _, _],
+        [_, _, _, _, _, _, _, _],
+        [_, _, _, _, _, O, O, O],
+        [_, _, _, _, _, i, Q, O],
+      ],
+      [7, 6]
+    );
+  });
+
+  it("Artillery should not be affected by a zone of control.", () => {
+    expectMoves(
+      [
+        [_, _, _, _, _, _, _, _],
+        [_, _, _, _, _, _, _, _],
+        [_, _, _, _, _, _, _, _],
+        [_, _, _, _, _, _, _, _],
+        [_, _, _, _, _, _, _, _],
+        [_, _, _, _, _, _, _, _],
+        [_, _, _, _, _, O, O, O],
+        [_, _, _, _, _, i, R, O],
+      ],
+      [7, 6]
     );
   });
 });


### PR DESCRIPTION
fixes #216

previously, HQs and artillery's movement was restricted by zones of control, which is incorrect