### PR TITLE
engine: disable turn moves from fen

### DIFF
--- a/src/game/engine-v2.ts
+++ b/src/game/engine-v2.ts
@@ -193,7 +193,8 @@ export function newGHQGameV2({
     G.redReserve = boardState.redReserve;
     G.blueReserve = boardState.blueReserve;
     G.v2state = fen;
-    G.thisTurnMoves = boardState.thisTurnMoves ?? [];
+    // TODO(tyler): figure out how to get this to work without overriding thisTurnMoves on the player's final turn
+    // G.thisTurnMoves = boardState.thisTurnMoves ?? [];
 
     G.eval = calculateEval({
       ...G,


### PR DESCRIPTION
this means you can't use fen to load a game mid-turn, but this is okay because it's causing some kind of major issues

fixes #241
fixes #242