### PR TITLE
fix auto captures

### DIFF
--- a/src/game/engine-v2.ts
+++ b/src/game/engine-v2.ts
@@ -15,7 +15,7 @@ import {
   UnitType,
 } from "./engine";
 import { allowedMoveFromUci, allowedMoveToUci } from "./notation-uci";
-import { FENtoBoardState } from "./notation";
+import { BoardState, FENtoBoardState } from "./notation";
 import { INVALID_MOVE } from "boardgame.io/core";
 import { calculateEval } from "./eval";
 import { LogAPI } from "boardgame.io/src/plugins/plugin-log";
@@ -28,7 +28,10 @@ export interface GameEngine {
   Move: {
     from_uci: (uci: string) => any;
   };
-  BaseBoard: (fen?: string) => PythonBoard;
+  BaseBoard: {
+    (fen?: string): PythonBoard;
+    deserialize: (serialized: string) => PythonBoard;
+  };
   RandomPlayer: (board: PythonBoard) => PythonPlayer;
   ValuePlayer: (board: PythonBoard) => PythonPlayer;
 }
@@ -36,8 +39,8 @@ export interface GameEngine {
 export class GameV2 {
   constructor(private engine: GameEngine) {}
 
-  generateLegalMoves(boardFen: string): AllowedMove[] {
-    const board = this.engine.BaseBoard(boardFen);
+  generateLegalMoves(v2state: string): AllowedMove[] {
+    const board = this.engine.BaseBoard.deserialize(v2state);
     const moves = board.generate_legal_moves();
     const ghqMoves = Array.from(moves).map((move) =>
       allowedMoveFromUci(move.uci())
@@ -45,25 +48,46 @@ export class GameV2 {
     return ghqMoves;
   }
 
-  isLegalMove(boardFen: string, ghqMove: AllowedMove): boolean {
-    const board = this.engine.BaseBoard(boardFen);
+  isLegalMove(v2state: string, ghqMove: AllowedMove): boolean {
+    const board = this.engine.BaseBoard.deserialize(v2state);
     const move = this.engine.Move.from_uci(allowedMoveToUci(ghqMove));
     return board.is_legal(move);
   }
 
-  push(boardFen: string, ghqMove: AllowedMove) {
-    const board = this.engine.BaseBoard(boardFen);
+  push(
+    v2state: string,
+    ghqMove: AllowedMove
+  ): { boardState: BoardState; v2state: string } {
+    const board = this.engine.BaseBoard.deserialize(v2state);
     const move = this.engine.Move.from_uci(allowedMoveToUci(ghqMove));
     board.push(move);
-    return board.board_fen();
+    return {
+      boardState: FENtoBoardState(board.board_fen()),
+      v2state: board.serialize(),
+    };
   }
 
-  defaultBoardFen(): string {
-    return this.engine.BaseBoard().board_fen();
+  boardStatesFromFen(fen?: string): {
+    boardState: BoardState;
+    v2state: string;
+  } {
+    const board = this.engine.BaseBoard(fen);
+    return {
+      boardState: FENtoBoardState(board.board_fen()),
+      v2state: board.serialize(),
+    };
   }
 
-  currentPlayerTurn(boardFen: string): Player {
-    const board = this.engine.BaseBoard(boardFen);
+  boardStates(v2state: string): { boardState: BoardState; v2state: string } {
+    const board = this.engine.BaseBoard.deserialize(v2state);
+    return {
+      boardState: FENtoBoardState(board.board_fen()),
+      v2state: board.serialize(),
+    };
+  }
+
+  currentPlayerTurn(v2state: string): Player {
+    const board = this.engine.BaseBoard.deserialize(v2state);
     return board.is_red_turn() ? "RED" : "BLUE";
   }
 }
@@ -76,6 +100,7 @@ export interface PythonBoard {
   generate_legal_moves: () => Iterable<PythonMove>;
   push: (move: PythonMove) => void;
   board_fen: () => string;
+  serialize: () => string;
   is_legal: (move: PythonMove) => boolean;
   is_red_turn: () => boolean;
   is_blue_turn: () => boolean;
@@ -115,8 +140,8 @@ export function newGHQGameV2({
     }
 
     updateMoveShim(ctx, G, log, move);
-    const boardFen = board.push(G.v2state, move);
-    updateStateFromFen(G, boardFen);
+    const states = board.push(G.v2state, move);
+    updateStateFromStates(G, states);
   }
 
   function updateMoveShim(
@@ -187,12 +212,14 @@ export function newGHQGameV2({
     }
   }
 
-  function updateStateFromFen(G: GHQState, fen: string) {
-    const boardState = FENtoBoardState(fen);
+  function updateStateFromStates(
+    G: GHQState,
+    { boardState, v2state }: { boardState: BoardState; v2state: string }
+  ) {
     G.board = boardState.board;
     G.redReserve = boardState.redReserve;
     G.blueReserve = boardState.blueReserve;
-    G.v2state = fen;
+    G.v2state = v2state;
     // TODO(tyler): figure out how to get this to work without overriding thisTurnMoves on the player's final turn
     // G.thisTurnMoves = boardState.thisTurnMoves ?? [];
 
@@ -210,7 +237,7 @@ export function newGHQGameV2({
       }
 
       const state = { ...v1Game.setup({ ctx, ...plugins }, setupData) };
-      updateStateFromFen(state, fen ?? board.defaultBoardFen());
+      updateStateFromStates(state, board.boardStatesFromFen(fen));
 
       if (type === "bot") {
         applyBotOptions(state);
@@ -258,7 +285,7 @@ export function newGHQGameV2({
           }
 
           // If it's already the next player's turn, end the turn without sending a move.
-          const boardState = FENtoBoardState(G.v2state);
+          const { boardState } = board.boardStates(G.v2state);
           if (boardState.currentPlayerTurn !== ctxPlayerToPlayer(ctx)) {
             events.endTurn();
             return;
@@ -285,7 +312,7 @@ export function newGHQGameV2({
         }
 
         // If it's already the next player's turn, end the turn without sending a move.
-        const boardState = FENtoBoardState(G.v2state);
+        const { boardState } = board.boardStates(G.v2state);
         if (boardState.currentPlayerTurn !== ctxPlayerToPlayer(ctx)) {
           events.endTurn();
           return;

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -750,7 +750,7 @@ export function isMoveCapture(move: AllowedMove) {
   if (move.name === "Reinforce" && move.args[2]) {
     return true;
   }
-  if (move.name === "AutoCapture" && move.args[0] === "free") {
+  if (move.name === "AutoCapture") {
     return true;
   }
 

--- a/src/game/notation.test.ts
+++ b/src/game/notation.test.ts
@@ -4,58 +4,58 @@ import { boards } from "./tutorial";
 import { defaultBoard, defaultReserveFleet } from "./engine";
 
 const notations = [
-  "qr↓6/iii5/8/8/8/8/5III/6R↑Q IIIIIFFFPRRTH iiiiifffprrth r -",
-  "q7/8/4h↓3/8/8/8/8/3P3Q - - r -",
-  "qI6/8/1I6/8/8/8/8/7Q - - r -",
-  "q7/8/8/3i4/3II3/8/8/7Q - - r -",
-  "q7/1r↓6/1I6/8/8/8/8/7Q IIIIIFFFPRRTH iiiiifffprrth r -",
-  "8/8/1i6/2r↓5/1I6/8/8/8 - - r -",
-  "8/8/1i6/r↓1r↓5/8/8/8/1P6 - - r -",
-  "8/8/1i6/1Ii5/8/8/8/1P6 - - r -",
-  "8/8/1i6/1Ir↓5/2I5/8/8/1P6 - - r -",
-  "qr↓6/iii5/8/8/8/8/5III/4P1R↑Q - - r -",
-  "qr↓1p4/iii5/8/8/8/8/5III/6R↑Q - - r -",
-  "8/1iI5/1I1I4/8/8/8/8/8 - - r a1a2",
-  "8/1i6/8/1Ii5/8/8/8/8 - - r -",
-  "8/8/1iI5/1Ii1iI2/Ii1I4/8/8/8 - - r -",
-  "8/8/1iI5/1IiI4/I1Ii4/1ii5/8/8 - - r -",
-  "8/2R↑5/1R↑6/3i4/8/8/8/8 - - r -",
-  "1p6/8/8/1Ii5/8/8/8/8 - - r -",
-  "1f6/8/8/1Ii5/8/8/8/8 - - r -",
-  "1f6/8/8/1Qi5/8/8/8/8 - - r -",
-  "8/1i6/8/1Q6/8/8/8/8 - - r -",
-  "p7/8/8/8/8/8/6R↑1/7Q - - r -",
-  "8/8/8/8/7i/6i1/7P/7q - - r -",
-  "8/8/8/8/8/8/6iq/6I1 - - r -",
-  "8/8/8/8/8/8/7R↑/5I1q - - r -",
-  "I7/1p6/1If5/8/8/8/8/8 - - r -",
-  "8/8/8/8/4r←3/4I3/8/8 - - r a1a2",
-  "8/8/8/8/4r←3/4I3/8/8 - - r a1a2",
-  "8/8/8/8/4r→3/4I3/8/8 - - r a1a2",
-  "8/8/8/8/4r→3/4I3/8/8 - - r a1a2",
-  "8/8/8/8/3Ir↑3/8/8/8 - - r a1a2",
-  "8/8/8/8/3Ir↑3/8/8/8 - - r a1a2",
-  "8/8/8/8/3Ir↓3/8/8/8 - - r a1a2",
-  "8/8/8/8/3Ir↓3/8/8/8 - - r a1a2",
-  "8/8/8/8/3Iq3/8/8/8 - - r -",
-  "8/8/5i2/6R↑i/5IiI/8/8/8 - - r -",
-  "q7/8/8/8/8/8/8/1I5Q - - r rib1",
-  "q7/8/8/8/8/8/I7/7Q - - r a1a2",
-  "q7/8/8/8/8/8/I7/F6Q - - r -",
-  "q7/8/8/8/8/8/I7/T↑6Q - - r -",
-  "qr6/F7/8/8/8/8/8/7Q - - r -",
-  "1r↘6/q7/1F6/8/8/8/8/7Q - - r -",
-  "q7/8/8/8/8/r↓7/8/7Q I - r -",
-  "q7/8/1i6/2fff3/2III3/5F2/8/7Q - - r -",
-  "q7/8/8/8/8/3f4/3F4/7Q - - r -",
-  "q7/8/3i4/8/2Ir↓f3/3I4/8/7Q - - r a1a2",
-  "q7/8/8/2i5/3r↓I3/1I6/8/7Q - - r a1a2",
-  "q7/8/8/8/8/1i6/8/T↑6Q - - r -",
-  "q5i1/8/7T↗/8/8/8/6Q1/8 - - b -",
-  "q5i1/8/6T↗1/8/8/8/6Q1/8 - - b -",
-  "q5i1/5i2/8/5H↗2/8/8/8/7Q - - b -",
-  "1IiIi3/1iIi4/3I4/2IqIi2/2fI1I2/3iIi2/8/7Q - - r -",
-  "1IiIi3/1iIi4/3I4/2IqIi2/2fI1I2/3iIi2/8/7Q - - r sff3",
+  "qr↓6/iii5/8/8/8/8/5III/6R↑Q IIIIIFFFPRRTH iiiiifffprrth r",
+  "q7/8/4h↓3/8/8/8/8/3P3Q - - r",
+  "qI6/8/1I6/8/8/8/8/7Q - - r",
+  "q7/8/8/3i4/3II3/8/8/7Q - - r",
+  "q7/1r↓6/1I6/8/8/8/8/7Q IIIIIFFFPRRTH iiiiifffprrth r",
+  "8/8/1i6/2r↓5/1I6/8/8/8 - - r",
+  "8/8/1i6/r↓1r↓5/8/8/8/1P6 - - r",
+  "8/8/1i6/1Ii5/8/8/8/1P6 - - r",
+  "8/8/1i6/1Ir↓5/2I5/8/8/1P6 - - r",
+  "qr↓6/iii5/8/8/8/8/5III/4P1R↑Q - - r",
+  "qr↓1p4/iii5/8/8/8/8/5III/6R↑Q - - r",
+  "8/1iI5/1I1I4/8/8/8/8/8 - - r",
+  "8/1i6/8/1Ii5/8/8/8/8 - - r",
+  "8/8/1iI5/1Ii1iI2/Ii1I4/8/8/8 - - r",
+  "8/8/1iI5/1IiI4/I1Ii4/1ii5/8/8 - - r",
+  "8/2R↑5/1R↑6/3i4/8/8/8/8 - - r",
+  "1p6/8/8/1Ii5/8/8/8/8 - - r",
+  "1f6/8/8/1Ii5/8/8/8/8 - - r",
+  "1f6/8/8/1Qi5/8/8/8/8 - - r",
+  "8/1i6/8/1Q6/8/8/8/8 - - r",
+  "p7/8/8/8/8/8/6R↑1/7Q - - r",
+  "8/8/8/8/7i/6i1/7P/7q - - r",
+  "8/8/8/8/8/8/6iq/6I1 - - r",
+  "8/8/8/8/8/8/7R↑/5I1q - - r",
+  "I7/1p6/1If5/8/8/8/8/8 - - r",
+  "8/8/8/8/4r←3/4I3/8/8 - - r",
+  "8/8/8/8/4r←3/4I3/8/8 - - r",
+  "8/8/8/8/4r→3/4I3/8/8 - - r",
+  "8/8/8/8/4r→3/4I3/8/8 - - r",
+  "8/8/8/8/3Ir↑3/8/8/8 - - r",
+  "8/8/8/8/3Ir↑3/8/8/8 - - r",
+  "8/8/8/8/3Ir↓3/8/8/8 - - r",
+  "8/8/8/8/3Ir↓3/8/8/8 - - r",
+  "8/8/8/8/3Iq3/8/8/8 - - r",
+  "8/8/5i2/6R↑i/5IiI/8/8/8 - - r",
+  "q7/8/8/8/8/8/8/1I5Q - - r",
+  "q7/8/8/8/8/8/I7/7Q - - r",
+  "q7/8/8/8/8/8/I7/F6Q - - r",
+  "q7/8/8/8/8/8/I7/T↑6Q - - r",
+  "qr6/F7/8/8/8/8/8/7Q - - r",
+  "1r↘6/q7/1F6/8/8/8/8/7Q - - r",
+  "q7/8/8/8/8/r↓7/8/7Q I - r",
+  "q7/8/1i6/2fff3/2III3/5F2/8/7Q - - r",
+  "q7/8/8/8/8/3f4/3F4/7Q - - r",
+  "q7/8/3i4/8/2Ir↓f3/3I4/8/7Q - - r",
+  "q7/8/8/2i5/3r↓I3/1I6/8/7Q - - r",
+  "q7/8/8/8/8/1i6/8/T↑6Q - - r",
+  "q5i1/8/7T↗/8/8/8/6Q1/8 - - b",
+  "q5i1/8/6T↗1/8/8/8/6Q1/8 - - b",
+  "q5i1/5i2/8/5H↗2/8/8/8/7Q - - b",
+  "1IiIi3/1iIi4/3I4/2IqIi2/2fI1I2/3iIi2/8/7Q - - r",
+  "1IiIi3/1iIi4/3I4/2IqIi2/2fI1I2/3iIi2/8/7Q - - r",
 ];
 
 describe("fen", () => {
@@ -65,9 +65,6 @@ describe("fen", () => {
       const newBoard = FENtoBoardState(fen);
       if (!boardState.currentPlayerTurn) {
         delete newBoard.currentPlayerTurn;
-      }
-      if (!boardState.thisTurnMoves) {
-        delete newBoard.thisTurnMoves;
       }
       expect(newBoard).toEqual(boardState);
     });
@@ -79,11 +76,10 @@ describe("fen", () => {
       redReserve: defaultReserveFleet,
       blueReserve: defaultReserveFleet,
       currentPlayerTurn: "RED",
-      thisTurnMoves: [],
     };
     const fen = boardToFEN(boardState);
     expect(fen).toEqual(
-      "qr↓6/iii5/8/8/8/8/5III/6R↑Q IIIIIFFFPRRTH iiiiifffprrth r -"
+      "qr↓6/iii5/8/8/8/8/5III/6R↑Q IIIIIFFFPRRTH iiiiifffprrth r"
     );
     const newBoard = FENtoBoardState(fen);
     expect(newBoard).toEqual(boardState);

--- a/src/game/notation.ts
+++ b/src/game/notation.ts
@@ -59,7 +59,6 @@ export interface BoardState {
   redReserve: ReserveFleet;
   blueReserve: ReserveFleet;
   currentPlayerTurn?: Player;
-  thisTurnMoves?: AllowedMove[];
 }
 
 // Inspired by https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
@@ -69,7 +68,6 @@ export function boardToFEN({
   redReserve,
   blueReserve,
   currentPlayerTurn,
-  thisTurnMoves,
 }: BoardState): string {
   let fen = "";
 
@@ -112,14 +110,6 @@ export function boardToFEN({
   fen += " ";
 
   fen += (currentPlayerTurn ?? "RED") === "RED" ? "r" : "b";
-
-  fen += " ";
-
-  if (thisTurnMoves && thisTurnMoves.length > 0) {
-    fen += thisTurnMoves.map(allowedMoveToUci).join(",");
-  } else {
-    fen += "-";
-  }
 
   return fen;
 }
@@ -198,14 +188,7 @@ export function FENtoBoardState(fen: string): BoardState {
 
   const currentPlayerTurn = currentPlayerFen === "r" ? "RED" : "BLUE";
 
-  const thisTurnMoves: AllowedMove[] = [];
-  if (movesFen && movesFen !== "-") {
-    for (const moveUci of movesFen.split(",")) {
-      thisTurnMoves.push(allowedMoveFromUci(moveUci));
-    }
-  }
-
-  return { board, redReserve, blueReserve, currentPlayerTurn, thisTurnMoves };
+  return { board, redReserve, blueReserve, currentPlayerTurn };
 }
 
 function parseFENChar(char: string): {

--- a/src/game/tests/board-moves.test.ts
+++ b/src/game/tests/board-moves.test.ts
@@ -6,6 +6,7 @@ import { allowedMoveToUci } from "../notation-uci";
 interface LegalMovesTest {
   description: string;
   boardFEN: string;
+  moves?: string[];
   expectedMovesUCI: string;
 }
 
@@ -208,88 +209,91 @@ const LEGAL_MOVES_TESTS: LegalMovesTest[] = [
     expectedMovesUCI:
       "g5g6↑ g5g6↗ g5g6→ g5g6↘ g5g6↓ g5g6↙ g5g6← g5g6↖ g5h6↑ g5h6↗ g5h6→ g5h6↘ g5h6↓ g5h6↙ g5h6← g5h6↖ g5f5↑ g5f5↗ g5f5→ g5f5↘ g5f5↓ g5f5↙ g5f5← g5f5↖ g5g5↗ g5g5→ g5g5↘ g5g5↓ g5g5↙ g5g5← g5g5↖ f4e5 f4e4 f4e3 f4f3 h4h3",
   },
-  {
-    boardFEN: "q↓7/8/8/8/8/8/8/1I5Q↑ - - r rib1",
-    description: "can't move a piece that was just reinforced",
-    expectedMovesUCI: "h1g2 h1h2 h1g1 skip",
-  },
-  {
-    boardFEN: "q↓7/8/8/8/8/8/I7/7Q↑ - - r a1a2",
-    description: "can't move a piece that's already been moved this turn",
-    expectedMovesUCI: "h1g2 h1h2 h1g1 skip",
-  },
+  // TODO(tyler): add these back in
+  // {
+  //   boardFEN: "q↓7/8/8/8/8/8/8/7Q↑ - - r",
+  //   description: "can't move a piece that was just reinforced",
+  //   moves: ["rib1"],
+  //   expectedMovesUCI: "h1g2 h1h2 h1g1 skip",
+  // },
+  // {
+  //   boardFEN: "q↓7/8/8/8/8/8/8/I6Q↑ - - r",
+  //   description: "can't move a piece that's already been moved this turn",
+  //   moves: ["a1a2"],
+  //   expectedMovesUCI: "h1g2 h1h2 h1g1 skip",
+  // },
   {
     description: "armored infantry can't move through your own pieces",
-    boardFEN: "q7/8/8/8/8/8/I↑7/F6Q - - r -",
+    boardFEN: "q7/8/8/8/8/8/I↑7/F6Q - - r",
     expectedMovesUCI: "a2a3 a2b3 a2b2 a2b1 a1b2 a1c3 a1b1 a1c1 h1g2 h1h2 h1g1",
   },
   {
     description: "armored artillery can't move through your own pieces",
-    boardFEN: "q7/8/8/8/8/8/I↑7/T↑6Q - - r -",
+    boardFEN: "q7/8/8/8/8/8/I↑7/T↑6Q - - r",
     expectedMovesUCI:
       "a2a3 a2b3 a2b2 a2b1 a1b2↑ a1b2↗ a1b2→ a1b2↘ a1b2↓ a1b2↙ a1b2← a1b2↖ a1c3↑ a1c3↗ a1c3→ a1c3↘ a1c3↓ a1c3↙ a1c3← a1c3↖ a1b1↑ a1b1↗ a1b1→ a1b1↘ a1b1↓ a1b1↙ a1b1← a1b1↖ a1c1↑ a1c1↗ a1c1→ a1c1↘ a1c1↓ a1c1↙ a1c1← a1c1↖ a1a1↗ a1a1→ a1a1↘ a1a1↓ a1a1↙ a1a1← a1a1↖ h1g2 h1h2 h1g1",
   },
   {
     description: "armored infantry can't move through bombardment 1",
-    boardFEN: "qr↓6/F↑7/8/8/8/8/8/7Q↑ - - r -",
+    boardFEN: "qr↓6/F↑7/8/8/8/8/8/7Q↑ - - r",
     expectedMovesUCI: "a7a6 a7a5 h1g2 h1h2 h1g1",
   },
   {
     description: "armored infantry can't move through bombardment 1",
-    boardFEN: "1r↘6/q7/1F↑6/8/8/8/8/7Q↑ - - r -",
+    boardFEN: "1r↘6/q7/1F↑6/8/8/8/8/7Q↑ - - r",
     expectedMovesUCI:
       "b6b7 b6b7xb8 b6a6 b6c6 b6a5 b6b5 b6b4 b6c5 b6d4 h1g2 h1h2 h1g1",
   },
   {
     description: "can't deploy reserves onto bombarded squares",
-    boardFEN: "q7/8/8/8/8/r↓7/8/7Q I - r -",
+    boardFEN: "q7/8/8/8/8/r↓7/8/7Q I - r",
     expectedMovesUCI: "rib1 ric1 rid1 rie1 rif1 rig1 h1g2 h1h2 h1g1",
   },
   {
     description: "puzzle: collapse the center line",
-    boardFEN: "q7/8/1i6/2fff3/2III3/5F2/8/7Q - - r -",
+    boardFEN: "q7/8/1i6/2fff3/2III3/5F2/8/7Q - - r",
     expectedMovesUCI:
       "c4b4 c4b3 c4c3 c4d3 d4c3 d4d3 d4e3 e4f4 e4d3 e4e3 f3f4 f3f5 f3f5xe5 f3g4 f3h5 f3e3 f3d3 f3g3 f3h3 f3e2 f3d1 f3f2 f3f1 f3g2 h1g2 h1h2 h1g1",
   },
   {
     description: "armored infantry blocked by infantry",
-    boardFEN: "q7/8/8/8/8/3f↓4/3F↑4/7Q - - r -",
+    boardFEN: "q7/8/8/8/8/3f↓4/3F↑4/7Q - - r",
     expectedMovesUCI: "d2c2 d2b2 d2e2 d2f2 d2c1 d2d1 d2e1 h1g2 h1h2 h1g1",
   },
   {
     description: "capture scenario #31",
-    boardFEN: "q7/8/3i↓4/8/2I↑r↓f↓3/3I↑4/8/7Q - - r -",
+    boardFEN: "q7/8/3i↓4/8/2I↑r↓f↓3/3I↑4/8/7Q - - r",
     expectedMovesUCI:
       "c4b5 c4c5 c4d5 c4b4 c4b3 c4c3 d3c3 d3e3 d3c2 d3e2 h1g2 h1h2 h1g1",
   },
   {
     description: "capture scenario #32",
-    boardFEN: "q7/8/8/2i↓5/3r↓I↑3/1I↑6/8/7Q - - r -",
+    boardFEN: "q7/8/8/2i↓5/3r↓I↑3/1I↑6/8/7Q - - r",
     expectedMovesUCI:
       "e4d5 e4e5 e4f5 e4f4 e4e3 e4f3 b3a4 b3b4 b3c4 b3a3 b3c3 b3a2 b3b2 b3c2 h1g2 h1h2 h1g1",
   },
   {
     description: "infantry shouldn't block armored artillery movement",
-    boardFEN: "q7/8/8/8/8/1i6/8/T↑6Q - - r -",
+    boardFEN: "q7/8/8/8/8/1i6/8/T↑6Q - - r",
     expectedMovesUCI:
       "a1a2↑ a1a2↗ a1a2→ a1a2↘ a1a2↓ a1a2↙ a1a2← a1a2↖ a1a3↑ a1a3↗ a1a3→ a1a3↘ a1a3↓ a1a3↙ a1a3← a1a3↖ a1b2↑ a1b2↗ a1b2→ a1b2↘ a1b2↓ a1b2↙ a1b2← a1b2↖ a1c3↑ a1c3↗ a1c3→ a1c3↘ a1c3↓ a1c3↙ a1c3← a1c3↖ a1b1↑ a1b1↗ a1b1→ a1b1↘ a1b1↓ a1b1↙ a1b1← a1b1↖ a1c1↑ a1c1↗ a1c1→ a1c1↘ a1c1↓ a1c1↙ a1c1← a1c1↖ a1a1↗ a1a1→ a1a1↘ a1a1↓ a1a1↙ a1a1← a1a1↖ h1g2 h1h2 h1g1",
   },
   {
     description:
       "artillery pointed off screen shouldn't bombard squares on the bombard",
-    boardFEN: "q5i1/8/7T↗/8/8/8/6Q1/8 - - b -",
+    boardFEN: "q5i1/8/7T↗/8/8/8/6Q1/8 - - b",
     expectedMovesUCI: "a8b8 a8a7 a8b7 g8f8 g8h8 g8f7 g8g7 g8h7 g8h7xh6",
   },
   {
     description:
       "artillery pointed off screen shouldn't bombard squares on the bombard 2",
-    boardFEN: "q5i1/8/6T↗1/8/8/8/6Q1/8 - - b -",
+    boardFEN: "q5i1/8/6T↗1/8/8/8/6Q1/8 - - b",
     expectedMovesUCI: "a8b8 a8a7 a8b7 g8f8 g8h8 g8f7 g8g7 g8g7xg6",
   },
   {
     description:
       "artillery pointed off screen shouldn't bombard squares on the bombard 3",
-    boardFEN: "q5i1/5i2/8/5H↗2/8/8/8/7Q - - b -",
+    boardFEN: "q5i1/5i2/8/5H↗2/8/8/8/7Q - - b",
     expectedMovesUCI:
       "a8b8 a8a7 a8b7 g8f8 g8h8 g8g7 f7e8 f7f8 f7e7 f7g7 f7e6 f7f6 f7f6xf5",
   },
@@ -313,7 +317,7 @@ describe("legal moves", () => {
         redReserve: board.redReserve,
         blueReserve: board.blueReserve,
         currentPlayerTurn: board.currentPlayerTurn ?? "RED", // TODO(tyler): this should come from the FEN
-        thisTurnMoves: board.thisTurnMoves ?? [],
+        thisTurnMoves: [],
       });
 
       const expectedMoves = test.expectedMovesUCI.split(" ");


### PR DESCRIPTION
also adds some other engine updates, such as draw when both players skip their turn

the important change in this PR is that we no longer add the list of `moves` to the
FEN string, since it doesn't adequately represent the full state of the board. hopefully
we can add it back later

and we have a full `serialize()` function now that encompasses all needed state