### PR TITLE
Replace two puzzles

### DIFF
--- a/src/game/tutorial.ts
+++ b/src/game/tutorial.ts
@@ -509,7 +509,7 @@ export function getBoardInfo(
   if (boardType) {
     const data = boards[boardType];
 
-    if ('fen' in data && data.fen) {
+    if (data?.fen) {
       const boardState = FENtoBoardState(data.fen);
       return { ...data, boardState };
     }


### PR DESCRIPTION
It's the two puzzles we removed in PR #251

The getBoardInfo function has been tweaked to allow for pasting FENs, which is how the replacement puzzles were added.