### PR TITLE
Tutorial: Two more slides, Back button, no more Auto-advancement

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -177,5 +177,18 @@ body {
 }
 
 .tutorial-link {
-  @apply bg-blue-400 text-gray-50 font-semibold p-3 px-10 rounded-2xl;
+  @apply bg-blue-400 text-gray-50 font-semibold py-2.5 px-10 rounded-2xl;
+}
+
+.tutorial-bot-button {
+  @apply bg-green-500;
+}
+
+/* Responsive styling for last slide buttons on narrow screens */
+@media (max-width: 500px) {
+  /* Shrink both buttons when space gets tight */
+  .tutorial-bot-button,
+  .tutorial-link:has(~ .tutorial-bot-button) {
+    @apply px-2;
+  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -177,12 +177,20 @@ body {
 }
 
 .tutorial-link {
-  @apply bg-blue-400 text-gray-50 font-semibold py-2.5 px-10 rounded-2xl;
+  @apply bg-blue-400 text-gray-50 font-semibold py-2.5 px-10 rounded-2xl transition-colors duration-200;
+}
+
+.tutorial-link:hover {
+  @apply bg-blue-500;
 }
 
 /* Darker Next button when encourageAdvance is true */
 .encourage-advance .tutorial-link:last-child {
   @apply bg-blue-600;
+}
+
+.encourage-advance .tutorial-link:last-child:hover {
+  @apply bg-blue-700;
 }
 
 .tutorial-bot-button {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -184,12 +184,12 @@ body {
   @apply bg-blue-500;
 }
 
-/* Darker Next button when encourageAdvance is true */
-.encourage-advance .tutorial-link:last-child {
+/* Darker Next button when encourageAdvance is true (but not bot button) */
+.encourage-advance .tutorial-link:last-child:not(.tutorial-bot-button) {
   @apply bg-blue-600;
 }
 
-.encourage-advance .tutorial-link:last-child:hover {
+.encourage-advance .tutorial-link:last-child:not(.tutorial-bot-button):hover {
   @apply bg-blue-700;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -180,6 +180,11 @@ body {
   @apply bg-blue-400 text-gray-50 font-semibold py-2.5 px-10 rounded-2xl;
 }
 
+/* Darker Next button when encourageAdvance is true */
+.encourage-advance .tutorial-link:last-child {
+  @apply bg-blue-600;
+}
+
 .tutorial-bot-button {
   @apply bg-green-500;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -176,36 +176,4 @@ body {
   }
 }
 
-.tutorial-link {
-  @apply bg-blue-400 text-gray-50 font-semibold py-2.5 px-10 rounded-2xl transition-colors duration-200;
-}
 
-.tutorial-link:hover {
-  @apply bg-blue-500;
-}
-
-/* Darker Next button when encourageAdvance is true (but not bot button) */
-.encourage-advance .tutorial-link:last-child:not(.tutorial-bot-button) {
-  @apply bg-blue-600;
-}
-
-.encourage-advance .tutorial-link:last-child:not(.tutorial-bot-button):hover {
-  @apply bg-blue-700;
-}
-
-.tutorial-bot-button {
-  @apply bg-green-500;
-}
-
-.tutorial-bot-button:hover {
-  @apply bg-green-600;
-}
-
-/* Responsive styling for last slide buttons on narrow screens */
-@media (max-width: 500px) {
-  /* Shrink both buttons when space gets tight */
-  .tutorial-bot-button,
-  .tutorial-link:has(~ .tutorial-bot-button) {
-    @apply px-2;
-  }
-}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -197,6 +197,10 @@ body {
   @apply bg-green-500;
 }
 
+.tutorial-bot-button:hover {
+  @apply bg-green-600;
+}
+
 /* Responsive styling for last slide buttons on narrow screens */
 @media (max-width: 500px) {
   /* Shrink both buttons when space gets tight */

--- a/src/app/tutorial/[frame]/page.tsx
+++ b/src/app/tutorial/[frame]/page.tsx
@@ -1,6 +1,5 @@
 import { frames } from "@/app/tutorial/frames";
 import { redirect } from "next/navigation";
-import Link from "next/link";
 
 import { TutorialBoard } from "@/app/tutorial/tutorial-board";
 import { LatestMoveProvider } from "@/components/LatestMoveContext";
@@ -28,29 +27,13 @@ export default async function Page({ params }: any) {
   
   return (
     <div className="max-w-4xl mx-auto pt-8 xs:text-left sm:text-center">
-      <div className="flex justify-center gap-4 relative z-10 mb-[-10px]">
-        {prev && (
-          <Link className="tutorial-link" href={prevLink}>
-            ◄ Back
-          </Link>
-        )}
-        {next ? (
-          <Link className="tutorial-link" href={nextLink}>
-            Next ►
-          </Link>
-        ) : (
-          <Link className={`tutorial-link ${!next ? 'tutorial-bot-button' : ''}`} href={`/bot`}>
-            Play your first game against a bot!
-          </Link>
-        )}
-      </div>
-
-      <div className="p-5 bg-gray-200">
-        <h1 className="text-2xl mb-4  font-bold">{tutorialFrame.heading}</h1>
-        <h3 className="text-xl px-2  ">{tutorialFrame.details}</h3>
-      </div>
       <LatestMoveProvider key={tutorialFrame.slugWithIndex}>
-        <TutorialBoard slug={tutorialFrame.slug} nextLink={nextLink} />
+        <TutorialBoard 
+          slug={tutorialFrame.slug} 
+          nextLink={nextLink}
+          prev={prev || undefined}
+          next={next || undefined}
+        />
       </LatestMoveProvider>
     </div>
   );

--- a/src/app/tutorial/[frame]/page.tsx
+++ b/src/app/tutorial/[frame]/page.tsx
@@ -21,19 +21,29 @@ export default async function Page({ params }: any) {
   }
 
   const next = frames[index + 1]?.slugWithIndex || false;
+  const prev = index > 0 ? frames[index - 1]?.slugWithIndex : false;
 
   const nextLink = `/tutorial/${next}`;
+  const prevLink = `/tutorial/${prev}`;
+  
   return (
-    <div className="max-w-4xl mx-auto pt-10 xs:text-left sm:text-center">
-      {next ? (
-        <Link className="tutorial-link" href={nextLink}>
-          Next ►
-        </Link>
-      ) : (
-        <Link className="tutorial-link" href={`/bot`}>
-          Play your first game against a bot!
-        </Link>
-      )}
+    <div className="max-w-4xl mx-auto pt-8 xs:text-left sm:text-center">
+      <div className="flex justify-center gap-4 relative z-10 mb-[-10px]">
+        {prev && (
+          <Link className="tutorial-link" href={prevLink}>
+            ◄ Back
+          </Link>
+        )}
+        {next ? (
+          <Link className="tutorial-link" href={nextLink}>
+            Next ►
+          </Link>
+        ) : (
+          <Link className={`tutorial-link ${!next ? 'tutorial-bot-button' : ''}`} href={`/bot`}>
+            Play your first game against a bot!
+          </Link>
+        )}
+      </div>
 
       <div className="p-5 bg-gray-200">
         <h1 className="text-2xl mb-4  font-bold">{tutorialFrame.heading}</h1>

--- a/src/app/tutorial/frames.ts
+++ b/src/app/tutorial/frames.ts
@@ -24,7 +24,8 @@ export type TutorialFrame = {
     moves: MoveLog[],
     next: () => void,
     reset: () => void,
-    message: (text: string) => void
+    message: (text: string) => void,
+    setEncourageAdvance: (value: boolean) => void
   ) => void;
 };
 
@@ -112,13 +113,15 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (last) {
       if (last.type === "Move" && last.unitType === "INFANTRY") {
         message("Perfect! You can go to the next slide now.");
+        setEncourageAdvance(true);
       } else {
         message("That's not an infantry!");
+        setEncourageAdvance(false);
       }
     }
   },
@@ -140,13 +143,15 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length && last) {
       if (last.type === "Move" && last.unitType === "ARMORED_INFANTRY") {
         message("Great! You can go to the next slide now.");
+        setEncourageAdvance(true);
       } else {
         message("That's not an armored infantry!");
+        setEncourageAdvance(false);
       }
     }
   },
@@ -169,14 +174,16 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length && last) {
       const bombarded = bombardedSquares(board);
       if (last.type === "MoveAndOrient" && Boolean(bombarded["2,2"])) {
         message("Nice! You can go to the next slide now.");
+        setEncourageAdvance(true);
       } else {
         message("You didn't aim at Blue's HQ. Try again!");
+        setEncourageAdvance(false);
         reset();
       }
     }
@@ -200,9 +207,14 @@ addFrame({
     [null, null, R.HA, null, R.AA, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const hasTwo = moves.filter((i) => i.type === "MoveAndOrient").length === 2;
-    if (hasTwo) message("Good! You can go to the next slide now.");
+    if (hasTwo) {
+      message("Good! You can go to the next slide now.");
+      setEncourageAdvance(true);
+    } else {
+      setEncourageAdvance(false);
+    }
   },
 });
 
@@ -221,15 +233,17 @@ addFrame({
     [null, null, null, R.IN, null, null, null, null],
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, null],
-    [null, null, null, null, null, null, null, R.HQ],
+    [null, null, null, null, R.AR, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (last) {
       if (last.type === "Move" && last.unitType === "INFANTRY") {
         message("Good! You can go to the next slide now.");
+        setEncourageAdvance(true);
       } else {
         message("That's not an infantry!");
+        setEncourageAdvance(false);
       }
     }
   },
@@ -252,11 +266,14 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (last) {
       if (last.unitType === "HEAVY_ARTILLERY") {
         message("See how you won their piece before your turn even started? You can go to the next slide now.");
+        setEncourageAdvance(true);
+      } else {
+        setEncourageAdvance(false);
       }
     }
   },
@@ -279,10 +296,13 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (last && last.type === "Reinforce") {
       message("Good! You can go to the next slide now.");
+      setEncourageAdvance(true);
+    } else {
+      setEncourageAdvance(false);
     }
   },
 });
@@ -303,11 +323,14 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (last) {
       if (last.type === "Move" && last.unitType === "INFANTRY") {
         message("Right, there's no way to capture this piece right now. Go to the next slide to see how.");
+        setEncourageAdvance(true);
+      } else {
+        setEncourageAdvance(false);
       }
     }
   },
@@ -330,16 +353,19 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length === 2 && last.type === "Move" && last.capturedPiece) {
       message("Bravo! You can go to the next slide.");
+      setEncourageAdvance(true);
       return;
     }
     if (moves.length === 1) {
       message("OK, one more move!");
+      setEncourageAdvance(false);
     } else if (moves.length === 2) {
       message("That's not it. Try to surround the piece next time");
+      setEncourageAdvance(false);
       reset();
     }
   },
@@ -362,8 +388,13 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
-    if (moves.length === 2) message("See? No captures. You can go to the next slide.");
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
+    if (moves.length === 2) {
+      message("See? No captures. You can go to the next slide.");
+      setEncourageAdvance(true);
+    } else {
+      setEncourageAdvance(false);
+    }
   },
 });
 addFrame({
@@ -382,15 +413,19 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length > 1 && last.type === "Move" && last.capturedPiece) {
       message("Nice! You can go to the next slide.");
+      setEncourageAdvance(true);
       return;
     }
     if (moves.length === 3 && !moves.some(move => move.type === "Move" && move.capturedPiece)) {
       message("That didn't work. Try again!");
+      setEncourageAdvance(false);
       reset();
+    } else {
+      setEncourageAdvance(false);
     }
   },
 });
@@ -412,13 +447,15 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length > 0) {
       if (last.type === "Move" && last.capturedPiece) {
         message("You got it! You can go to the next slide.");
+        setEncourageAdvance(true);
       } else {
         message("Line up next to the artillery");
+        setEncourageAdvance(false);
         reset();
       }
     }
@@ -442,14 +479,16 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length > 0) {
       if (last.type === "Move" && last.unitType === "INFANTRY" && last.to[0] === 2 && last.to[1] === 4) {
         message("Yes, notice how everything is safe. You can go to the next slide.");
+        setEncourageAdvance(true);
         return;
       } else {
         message("Try the same move as last time");
+        setEncourageAdvance(false);
         reset();
       }
     }
@@ -473,7 +512,7 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (
       last &&
@@ -483,18 +522,21 @@ addFrame({
       last.to[1] === 3
     ) {
       message("Right! You can go to the next slide.");
+      setEncourageAdvance(true);
       return;
     }
     if (moves.length &&
       last.unitType === "INFANTRY"
     ) {
       message("Not there! Or Infantry to D5 will capture your Artillery");
+      setEncourageAdvance(false);
       reset();
     }
     if (moves.length &&
       last.unitType === "ARTILLERY"
     ) {
       message("Let's only move the Infantry");
+      setEncourageAdvance(false);
       reset();
     }
   },
@@ -518,13 +560,15 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (last) {
       if (last.type === "Move" && last.unitType === "ARMORED_INFANTRY") {
         message("Good! You can go to the next slide.");
+        setEncourageAdvance(true);
       } else {
         message("That's not an infantry!");
+        setEncourageAdvance(false);
       }
     }
   },
@@ -547,7 +591,7 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, R.AB, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length) {
       if (
@@ -556,7 +600,9 @@ addFrame({
         last.unitType === "AIRBORNE_INFANTRY"
       ) {
         message("Currahee! You can go to the next slide.");
+        setEncourageAdvance(true);
       } else {
+        setEncourageAdvance(false);
         reset();
       }
     }
@@ -580,7 +626,7 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, R.AB, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length) {
       if (
@@ -590,7 +636,9 @@ addFrame({
         last.capturedPiece
       ) {
         message("Good! You can go to the next slide.");
+        setEncourageAdvance(true);
       } else {
+        setEncourageAdvance(false);
         reset();
       }
     }
@@ -614,7 +662,7 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, R.AB, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length) {
       if (
@@ -624,7 +672,9 @@ addFrame({
         last.capturedPiece
       ) {
         message("Good! You can go to the next slide.");
+        setEncourageAdvance(true);
       } else {
+        setEncourageAdvance(false);
         reset();
       }
     }
@@ -648,13 +698,15 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length === 2) {
       if (last && last.type === "Move" && last.capturedPiece) {
         message("Good! You can go to the next slide.");
+        setEncourageAdvance(true);
       } else {
         message("Capture their Infantry with a 2-on-1!");
+        setEncourageAdvance(false);
         reset();
       }
     }

--- a/src/app/tutorial/frames.ts
+++ b/src/app/tutorial/frames.ts
@@ -116,7 +116,7 @@ addFrame({
     const last = moves[moves.length - 1];
     if (last) {
       if (last.type === "Move" && last.unitType === "INFANTRY") {
-        next();
+        message("Perfect! You can go to the next slide now.");
       } else {
         message("That's not an infantry!");
       }
@@ -127,7 +127,7 @@ addFrame({
 addFrame({
   slug: "moving-armored-infantry",
   heading: "Move an Armored Infantry",
-  details: "Armored Infantry can move two squares in any one direction.",
+  details: "Armored Infantry can move up to two squares in any one direction.",
   redReserve: emptyReserveFleet,
   blueReserve: emptyReserveFleet,
   board: [
@@ -144,7 +144,7 @@ addFrame({
     const last = moves[moves.length - 1];
     if (moves.length && last) {
       if (last.type === "Move" && last.unitType === "ARMORED_INFANTRY") {
-        next();
+        message("Great! You can go to the next slide now.");
       } else {
         message("That's not an armored infantry!");
       }
@@ -173,9 +173,8 @@ addFrame({
     const last = moves[moves.length - 1];
     if (moves.length && last) {
       const bombarded = bombardedSquares(board);
-      console.log(bombarded);
       if (last.type === "MoveAndOrient" && Boolean(bombarded["2,2"])) {
-        next();
+        message("Nice! You can go to the next slide now.");
       } else {
         message("You didn't aim at Blue's HQ. Try again!");
         reset();
@@ -203,7 +202,7 @@ addFrame({
   ],
   didMove: (board, moves, next, reset, message) => {
     const hasTwo = moves.filter((i) => i.type === "MoveAndOrient").length === 2;
-    if (hasTwo) next();
+    if (hasTwo) message("Good! You can go to the next slide now.");
   },
 });
 
@@ -228,9 +227,36 @@ addFrame({
     const last = moves[moves.length - 1];
     if (last) {
       if (last.type === "Move" && last.unitType === "INFANTRY") {
-        next();
+        message("Good! You can go to the next slide now.");
       } else {
         message("That's not an infantry!");
+      }
+    }
+  },
+});
+
+addFrame({
+  slug: "capturing-with-artillery",
+  heading: "Artillery have a delayed attack",
+  details:
+    "If you aim at an enemy, you only capture their piece if they end their turn still under bombardment. If Blue ends their turn in the position below, they lose their piece!",
+  redReserve: emptyReserveFleet,
+  blueReserve: emptyReserveFleet,
+  board: [
+    [B.HQ, null, null, null, null, null, null, null],
+    [B.IN, B.IN, null, null, null, null, null, null],
+    [null, null, null, B.IN, null, null, null, null],
+    [null, null, null, null, null, null, null, null],
+    [null, null, null, R.HA, null, null, null, null],
+    [null, null, null, null, null, null, null, null],
+    [null, null, null, null, null, null, null, null],
+    [null, null, null, null, null, null, null, R.HQ],
+  ],
+  didMove: (board, moves, next, reset, message) => {
+    const last = moves[moves.length - 1];
+    if (last) {
+      if (last.unitType === "HEAVY_ARTILLERY") {
+        message("See how you won their piece before your turn even started? You can go to the next slide now.");
       }
     }
   },
@@ -256,7 +282,7 @@ addFrame({
   didMove: (board, moves, next, reset, message) => {
     const last = moves[moves.length - 1];
     if (last && last.type === "Reinforce") {
-      next();
+      message("Good! You can go to the next slide now.");
     }
   },
 });
@@ -281,7 +307,7 @@ addFrame({
     const last = moves[moves.length - 1];
     if (last) {
       if (last.type === "Move" && last.unitType === "INFANTRY") {
-        next();
+        message("Right, there's no way to capture this piece right now. Go to the next slide to see how.");
       }
     }
   },
@@ -307,10 +333,11 @@ addFrame({
   didMove: (board, moves, next, reset, message) => {
     const last = moves[moves.length - 1];
     if (moves.length === 2 && last.type === "Move" && last.capturedPiece) {
-      return next();
+      message("Bravo! You can go to the next slide.");
+      return;
     }
     if (moves.length === 1) {
-      message("Great one more move!");
+      message("OK, one more move!");
     } else if (moves.length === 2) {
       message("That's not it. Try to surround the piece next time");
       reset();
@@ -336,12 +363,12 @@ addFrame({
     [null, null, null, null, null, null, null, R.HQ],
   ],
   didMove: (board, moves, next, reset, message) => {
-    if (moves.length === 2) next();
+    if (moves.length === 2) message("See? No captures. You can go to the next slide.");
   },
 });
 addFrame({
   slug: "capturing-4",
-  heading: "Outnumber enemy Infantry to capture their pieces.",
+  heading: "Outnumber enemy Infantry to capture their pieces",
   details: "Can you figure out how to capture an infantry?",
   redReserve: emptyReserveFleet,
   blueReserve: emptyReserveFleet,
@@ -358,9 +385,10 @@ addFrame({
   didMove: (board, moves, next, reset, message) => {
     const last = moves[moves.length - 1];
     if (moves.length > 1 && last.type === "Move" && last.capturedPiece) {
-      return next();
+      message("Nice! You can go to the next slide.");
+      return;
     }
-    if (moves.length === 3) {
+    if (moves.length === 3 && !moves.some(move => move.type === "Move" && move.capturedPiece)) {
       message("That didn't work. Try again!");
       reset();
     }
@@ -388,7 +416,7 @@ addFrame({
     const last = moves[moves.length - 1];
     if (moves.length > 0) {
       if (last.type === "Move" && last.capturedPiece) {
-        return next();
+        message("You got it! You can go to the next slide.");
       } else {
         message("Line up next to the artillery");
         reset();
@@ -417,7 +445,13 @@ addFrame({
   didMove: (board, moves, next, reset, message) => {
     const last = moves[moves.length - 1];
     if (moves.length > 0) {
-      next();
+      if (last.type === "Move" && last.unitType === "INFANTRY" && last.to[0] === 2 && last.to[1] === 4) {
+        message("Yes, notice how everything is safe. You can go to the next slide.");
+        return;
+      } else {
+        message("Try the same move as last time");
+        reset();
+      }
     }
   },
 });
@@ -440,7 +474,6 @@ addFrame({
     [null, null, null, null, null, null, null, R.HQ],
   ],
   didMove: (board, moves, next, reset, message) => {
-    console.log(moves);
     const last = moves[moves.length - 1];
     if (
       last &&
@@ -449,12 +482,50 @@ addFrame({
       last.to[0] === 4 &&
       last.to[1] === 3
     ) {
-      return next();
+      message("Right! You can go to the next slide.");
+      return;
     }
-
-    if (moves.length) {
+    if (moves.length &&
+      last.unitType === "INFANTRY"
+    ) {
       message("Not there! Or Infantry to D5 will capture your Artillery");
       reset();
+    }
+    if (moves.length &&
+      last.unitType === "ARTILLERY"
+    ) {
+      message("Let's only move the Infantry");
+      reset();
+    }
+  },
+  
+});
+
+addFrame({
+  slug: "zones-of-control",
+  heading: "Engaged Infantry have some movement restrictions",
+  details:
+    "An engaged Infantry cannot move to or through any square where it could engage an infantry piece (including the same one they were engaged with). Notice how your mobility is limited here.",
+  redReserve: emptyReserveFleet,
+  blueReserve: emptyReserveFleet,
+  board: [
+    [B.HQ, null, null, null, null, null, null, null],
+    [null, null, null, null, null, null, null, null],
+    [null, null, null, null, null, null, null, null],
+    [null, null, B.IN, B.IN, null, null, null, null],
+    [null, null, null, R.AI, null, null, null, null],
+    [null, null, null, null, null, null, null, null],
+    [null, null, null, null, null, null, null, null],
+    [null, null, null, null, null, null, null, R.HQ],
+  ],
+  didMove: (board, moves, next, reset, message) => {
+    const last = moves[moves.length - 1];
+    if (last) {
+      if (last.type === "Move" && last.unitType === "ARMORED_INFANTRY") {
+        message("Good! You can go to the next slide.");
+      } else {
+        message("That's not an infantry!");
+      }
     }
   },
 });
@@ -463,7 +534,7 @@ addFrame({
   slug: "airborne",
   heading: "And now: the most powerful piece in the game",
   details:
-    "Each Player gets one Airborne Infantry that can parachute anywhere on the board in a moment's notice. Try it out!",
+    "Each Player gets one Airborne Infantry that can parachute from its own back row to anywhere on the board at a moment's notice. Try it out!",
   redReserve: emptyReserveFleet,
   blueReserve: emptyReserveFleet,
   board: [
@@ -484,7 +555,7 @@ addFrame({
         last.type === "Move" &&
         last.unitType === "AIRBORNE_INFANTRY"
       ) {
-        next();
+        message("Currahee! You can go to the next slide.");
       } else {
         reset();
       }
@@ -518,7 +589,7 @@ addFrame({
         last.unitType === "AIRBORNE_INFANTRY" &&
         last.capturedPiece
       ) {
-        return next();
+        message("Good! You can go to the next slide.");
       } else {
         reset();
       }
@@ -530,7 +601,7 @@ addFrame({
   slug: "airborne-3",
   heading:
     "You can also use it to get unexpected two-on-one's against Infantry",
-  details: "Team up with your Basic Infantry to Capture Red's Armored Infantry.",
+  details: "Team up with your Basic Infantry to Capture Blue's Armored Infantry.",
   redReserve: emptyReserveFleet,
   blueReserve: emptyReserveFleet,
   board: [
@@ -552,7 +623,7 @@ addFrame({
         last.unitType === "AIRBORNE_INFANTRY" &&
         last.capturedPiece
       ) {
-        return next();
+        message("Good! You can go to the next slide.");
       } else {
         reset();
       }
@@ -564,7 +635,7 @@ addFrame({
   slug: "airborne-4",
   heading: "The Airborne can only jump from the back rank",
   details:
-    "Once it's in the game it behaves like a normal Infantry. Pro tip: if you walk it home you can use it again.",
+    "Once it's in the game it behaves like a normal Infantry. Use it like a normal infantry here to capture your opponent. Pro tip: if you walk it home you can use it again!",
   redReserve: emptyReserveFleet,
   blueReserve: emptyReserveFleet,
   board: [
@@ -581,8 +652,9 @@ addFrame({
     const last = moves[moves.length - 1];
     if (moves.length === 2) {
       if (last && last.type === "Move" && last.capturedPiece) {
-        return next();
+        message("Good! You can go to the next slide.");
       } else {
+        message("Capture their Infantry with a 2-on-1!");
         reset();
       }
     }
@@ -593,7 +665,7 @@ addFrame({
   slug: "summary",
   heading: "That's GHQ",
   details:
-    "3 Moves a Turn. Capture Infantry with 2:1s. Defend your Artillery. Have fun! If all goes well your game will end like this. To finish this tutorial capture the enemy HQ!!!",
+    "3 Moves a Turn. Capture Infantry with 2-on-1s. Defend your Artillery. Have fun! If all goes well your game will end like this. To finish this tutorial capture the enemy HQ!!!",
   redReserve: emptyReserveFleet,
   blueReserve: emptyReserveFleet,
   board: [
@@ -610,10 +682,11 @@ addFrame({
     const last = moves[moves.length - 1];
     if (moves.length === 2) {
       if (last && last.type === "Move" && last.capturedPiece) {
-        return next();
+        message("You got it! You're ready to play!");
       } else {
         reset();
       }
     }
   },
 });
+

--- a/src/app/tutorial/frames.ts
+++ b/src/app/tutorial/frames.ts
@@ -730,12 +730,14 @@ addFrame({
     [null, null, null, null, null, null, null, null],
     [null, null, null, null, null, null, null, R.HQ],
   ],
-  didMove: (board, moves, next, reset, message) => {
+  didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length === 2) {
       if (last && last.type === "Move" && last.capturedPiece) {
         message("You got it! You're ready to play!");
+        setEncourageAdvance(true);
       } else {
+        setEncourageAdvance(false);
         reset();
       }
     }

--- a/src/app/tutorial/frames.ts
+++ b/src/app/tutorial/frames.ts
@@ -117,7 +117,7 @@ addFrame({
     const last = moves[moves.length - 1];
     if (last) {
       if (last.type === "Move" && last.unitType === "INFANTRY") {
-        message("Perfect! You can go to the next slide now.");
+        message("Perfect!");
         setEncourageAdvance(true);
       } else {
         message("That's not an infantry!");
@@ -147,7 +147,7 @@ addFrame({
     const last = moves[moves.length - 1];
     if (moves.length && last) {
       if (last.type === "Move" && last.unitType === "ARMORED_INFANTRY") {
-        message("Great! You can go to the next slide now.");
+        message("Great!");
         setEncourageAdvance(true);
       } else {
         message("That's not an armored infantry!");
@@ -179,7 +179,7 @@ addFrame({
     if (moves.length && last) {
       const bombarded = bombardedSquares(board);
       if (last.type === "MoveAndOrient" && Boolean(bombarded["2,2"])) {
-        message("Nice! You can go to the next slide now.");
+        message("Nice!");
         setEncourageAdvance(true);
       } else {
         message("You didn't aim at Blue's HQ. Try again!");
@@ -210,7 +210,7 @@ addFrame({
   didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const hasTwo = moves.filter((i) => i.type === "MoveAndOrient").length === 2;
     if (hasTwo) {
-      message("Good! You can go to the next slide now.");
+      message("Good!");
       setEncourageAdvance(true);
     } else {
       setEncourageAdvance(false);
@@ -239,7 +239,7 @@ addFrame({
     const last = moves[moves.length - 1];
     if (last) {
       if (last.type === "Move" && last.unitType === "INFANTRY") {
-        message("Good! You can go to the next slide now.");
+        message("Good!");
         setEncourageAdvance(true);
       } else {
         message("That's not an infantry!");
@@ -270,7 +270,7 @@ addFrame({
     const last = moves[moves.length - 1];
     if (last) {
       if (last.unitType === "HEAVY_ARTILLERY") {
-        message("See how you won their piece before your turn even started? You can go to the next slide now.");
+        message("See how you won their piece before your turn even started?");
         setEncourageAdvance(true);
       } else {
         setEncourageAdvance(false);
@@ -299,7 +299,7 @@ addFrame({
   didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (last && last.type === "Reinforce") {
-      message("Good! You can go to the next slide now.");
+      message("Good!");
       setEncourageAdvance(true);
     } else {
       setEncourageAdvance(false);
@@ -356,7 +356,7 @@ addFrame({
   didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length === 2 && last.type === "Move" && last.capturedPiece) {
-      message("Bravo! You can go to the next slide.");
+      message("Bravo!");
       setEncourageAdvance(true);
       return;
     }
@@ -390,7 +390,7 @@ addFrame({
   ],
   didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     if (moves.length === 2) {
-      message("See? No captures. You can go to the next slide.");
+      message("See? No captures.");
       setEncourageAdvance(true);
     } else {
       setEncourageAdvance(false);
@@ -416,7 +416,7 @@ addFrame({
   didMove: (board, moves, next, reset, message, setEncourageAdvance) => {
     const last = moves[moves.length - 1];
     if (moves.length > 1 && last.type === "Move" && last.capturedPiece) {
-      message("Nice! You can go to the next slide.");
+      message("Nice!");
       setEncourageAdvance(true);
       return;
     }
@@ -451,7 +451,7 @@ addFrame({
     const last = moves[moves.length - 1];
     if (moves.length > 0) {
       if (last.type === "Move" && last.capturedPiece) {
-        message("You got it! You can go to the next slide.");
+        message("You got it!");
         setEncourageAdvance(true);
       } else {
         message("Line up next to the artillery");
@@ -483,7 +483,7 @@ addFrame({
     const last = moves[moves.length - 1];
     if (moves.length > 0) {
       if (last.type === "Move" && last.unitType === "INFANTRY" && last.to[0] === 2 && last.to[1] === 4) {
-        message("Yes, notice how everything is safe. You can go to the next slide.");
+        message("Yes, notice how everything is safe.");
         setEncourageAdvance(true);
         return;
       } else {
@@ -521,7 +521,7 @@ addFrame({
       last.to[0] === 4 &&
       last.to[1] === 3
     ) {
-      message("Right! You can go to the next slide.");
+      message("Right!");
       setEncourageAdvance(true);
       return;
     }
@@ -564,7 +564,7 @@ addFrame({
     const last = moves[moves.length - 1];
     if (last) {
       if (last.type === "Move" && last.unitType === "ARMORED_INFANTRY") {
-        message("Good! You can go to the next slide.");
+        message("Good!");
         setEncourageAdvance(true);
       } else {
         message("That's not an infantry!");
@@ -599,7 +599,7 @@ addFrame({
         last.type === "Move" &&
         last.unitType === "AIRBORNE_INFANTRY"
       ) {
-        message("Currahee! You can go to the next slide.");
+        message("Currahee!");
         setEncourageAdvance(true);
       } else {
         setEncourageAdvance(false);
@@ -635,7 +635,7 @@ addFrame({
         last.unitType === "AIRBORNE_INFANTRY" &&
         last.capturedPiece
       ) {
-        message("Good! You can go to the next slide.");
+        message("Good!");
         setEncourageAdvance(true);
       } else {
         setEncourageAdvance(false);
@@ -671,7 +671,7 @@ addFrame({
         last.unitType === "AIRBORNE_INFANTRY" &&
         last.capturedPiece
       ) {
-        message("Good! You can go to the next slide.");
+        message("Good!");
         setEncourageAdvance(true);
       } else {
         setEncourageAdvance(false);
@@ -702,7 +702,7 @@ addFrame({
     const last = moves[moves.length - 1];
     if (moves.length === 2) {
       if (last && last.type === "Move" && last.capturedPiece) {
-        message("Good! You can go to the next slide.");
+        message("Good!");
         setEncourageAdvance(true);
       } else {
         message("Capture their Infantry with a 2-on-1!");

--- a/src/app/tutorial/frames.ts
+++ b/src/app/tutorial/frames.ts
@@ -601,7 +601,7 @@ addFrame({
   slug: "airborne-3",
   heading:
     "You can also use it to get unexpected two-on-one's against Infantry",
-  details: "Team up with your Basic Infantry to Capture Blue's Armored Infantry.",
+  details: "Team up with your Basic Infantry to capture Blue's Armored Infantry.",
   redReserve: emptyReserveFleet,
   blueReserve: emptyReserveFleet,
   board: [

--- a/src/app/tutorial/tutorial-board.tsx
+++ b/src/app/tutorial/tutorial-board.tsx
@@ -166,7 +166,7 @@ export function TutorialBoard(props: { slug: string; nextLink: string }) {
       <div className="h-12 flex items-center justify-center">
         {message && (
           <h3 className={`text-md text-center ${
-            encourageAdvance ? 'text-green-600' : 'text-blue-900'
+            encourageAdvance ? 'text-green-700' : 'text-yellow-600'
           }`}>
             {message}
           </h3>

--- a/src/app/tutorial/tutorial-board.tsx
+++ b/src/app/tutorial/tutorial-board.tsx
@@ -136,9 +136,11 @@ export function TutorialBoard(props: { slug: string; nextLink: string }) {
 
   return (
     <>
-      {message && (
-        <h3 className="mt-5 text-md text-center text-blue-900 ">{message}</h3>
-      )}
+      <div className="h-12 flex items-center justify-center">
+        {message && (
+          <h3 className="text-md text-center text-blue-900">{message}</h3>
+        )}
+      </div>
 
       <div
         className={classNames("flex bg-gray-50 justify-center", {

--- a/src/app/tutorial/tutorial-board.tsx
+++ b/src/app/tutorial/tutorial-board.tsx
@@ -13,8 +13,14 @@ import { useBoardArrow } from "@/game/BoardArrowProvider";
 import { coordinateToAlgebraic, degreesToCardinal } from "@/game/notation";
 import { MoveLog } from "@/app/tutorial/types";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 
-export function TutorialBoard(props: { slug: string; nextLink: string }) {
+export function TutorialBoard(props: { 
+  slug: string; 
+  nextLink: string; 
+  prev?: string; 
+  next?: string; 
+}) {
   const [client, setClient] = useState<any | null>(null);
   const router = useRouter();
 
@@ -147,22 +153,53 @@ export function TutorialBoard(props: { slug: string; nextLink: string }) {
     }
   }, [tutorialFrame.slug]);
 
-  // Add/remove CSS class to body based on encourageAdvance state
-  useEffect(() => {
-    if (encourageAdvance) {
-      document.body.classList.add('encourage-advance');
-    } else {
-      document.body.classList.remove('encourage-advance');
-    }
+  // No longer need to manipulate body classes
 
-    // Cleanup on unmount
-    return () => {
-      document.body.classList.remove('encourage-advance');
-    };
-  }, [encourageAdvance]);
+  const prevLink = props.prev ? `/tutorial/${props.prev}` : null;
+  const nextLink = props.next ? `/tutorial/${props.next}` : null;
 
   return (
     <>
+      {/* Navigation */}
+      <div className="flex justify-center gap-4 relative z-10 mb-[-10px]">
+        {prevLink && (
+          <Link 
+            className={`bg-blue-400 hover:bg-blue-500 text-gray-50 font-semibold py-2.5 rounded-2xl transition-colors duration-200 ${
+              !nextLink ? 'max-[500px]:px-2 px-10' : 'px-10'
+            }`}
+            href={prevLink}
+          >
+            ◄ Back
+          </Link>
+        )}
+        {nextLink ? (
+          <Link 
+            className={`text-gray-50 font-semibold py-2.5 px-10 rounded-2xl transition-colors duration-200 ${
+              encourageAdvance 
+                ? 'bg-blue-600 hover:bg-blue-700' 
+                : 'bg-blue-400 hover:bg-blue-500'
+            }`}
+            href={nextLink}
+          >
+            Next ►
+          </Link>
+        ) : (
+          <Link 
+            className="bg-green-500 hover:bg-green-600 text-gray-50 font-semibold py-2.5 px-10 rounded-2xl transition-colors duration-200 max-[500px]:px-2"
+            href={`/bot`}
+          >
+            Play your first game against a bot!
+          </Link>
+        )}
+      </div>
+      
+      {/* Header */}
+      <div className="p-5 bg-gray-200">
+        <h1 className="text-2xl mb-4 font-bold">{tutorialFrame.heading}</h1>
+        <h3 className="text-xl px-2">{tutorialFrame.details}</h3>
+      </div>
+
+      {/* Message */}
       <div className="h-12 flex items-center justify-center">
         {message && (
           <h3 className={`text-md text-center ${
@@ -173,6 +210,7 @@ export function TutorialBoard(props: { slug: string; nextLink: string }) {
         )}
       </div>
 
+      {/* Game Board */}
       <div
         className={classNames("flex bg-gray-50 justify-center", {
           ["pointer-events-none"]: tutorialFrame.disablePlay,

--- a/src/app/tutorial/tutorial-board.tsx
+++ b/src/app/tutorial/tutorial-board.tsx
@@ -39,6 +39,7 @@ export function TutorialBoard(props: { slug: string; nextLink: string }) {
   }, [key, setKey]);
 
   const [message, setMessage] = useState<string | null>(null);
+  const [encourageAdvance, setEncourageAdvance] = useState(false);
 
   const App = useMemo(
     () =>
@@ -130,15 +131,45 @@ export function TutorialBoard(props: { slug: string; nextLink: string }) {
         })
         .filter((i) => typeof i !== "undefined");
 
-      tutorialFrame.didMove(board, playerMessages, next, reset, setMessage);
+      tutorialFrame.didMove(board, playerMessages, next, reset, setMessage, setEncourageAdvance);
     }
   }, [moves, board, tutorialFrame]);
+
+  // Initialize encourageAdvance based on whether the frame requires user action
+  useEffect(() => {
+    // For frames that don't have didMove, encourage advance immediately
+    if (!tutorialFrame.didMove) {
+      setEncourageAdvance(true);
+    }
+    // For frames with didMove, start with false (user needs to complete action)
+    else {
+      setEncourageAdvance(false);
+    }
+  }, [tutorialFrame.slug]);
+
+  // Add/remove CSS class to body based on encourageAdvance state
+  useEffect(() => {
+    if (encourageAdvance) {
+      document.body.classList.add('encourage-advance');
+    } else {
+      document.body.classList.remove('encourage-advance');
+    }
+
+    // Cleanup on unmount
+    return () => {
+      document.body.classList.remove('encourage-advance');
+    };
+  }, [encourageAdvance]);
 
   return (
     <>
       <div className="h-12 flex items-center justify-center">
         {message && (
-          <h3 className="text-md text-center text-blue-900">{message}</h3>
+          <h3 className={`text-md text-center ${
+            encourageAdvance ? 'text-green-600' : 'text-blue-900'
+          }`}>
+            {message}
+          </h3>
         )}
       </div>
 


### PR DESCRIPTION
### Removed auto-advancement

I removed the auto-advancement after you make the correct move. I think it's useful to be able to digest the solution for a bit rather than having a new scenario immediately load. (The downside is that there's more clicking now and it's wordier, but I still think it's worth it. I should have made this one change it's own commit to make it easier to reject if you don't like it, but I didn't, so hopefully we can just keep it and I'll keep this in mind for next time.)

New behavior (showing a message instead of advancing on its own):

<img width="599" height="654" alt="image" src="https://github.com/user-attachments/assets/5ef589f9-0b6a-40c8-b934-c69a77056fee" />

### Back buttons

Also pretty useful since it's natural to revisit topics.

And I made the Play Bot button green since it behaves a bit differently than the regular Next button.

I set the buttons to become smaller when the screen is narrow such that they still fit on one line on mobile:

<img width="498" height="756" alt="image" src="https://github.com/user-attachments/assets/c79dd066-11af-44b6-802a-672887d11c53" />

### Two new slides

These topics used to not be covered. They are a bit tricky to explain, but these seem decent for now. 

<img width="759" height="618" alt="image" src="https://github.com/user-attachments/assets/045236a7-5ada-4d9c-b362-c1d4486c0058" />
<img width="744" height="591" alt="image" src="https://github.com/user-attachments/assets/7a087254-b85e-4a23-bb58-6434c7387924" />

***

There may have been better ways to accomplish a lot of this. About half of my styling edits were done to try to keep things looking the same as they used to.

I also considered adding progress bar or "17/22" indicator, but I ended up not liking it because it made me want to rush through instead of just taking in each slide on its own.
