### PR TITLE
Fix mobile touch issues

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,6 +23,12 @@ const geistMono = localFont({
 export const metadata: Metadata = {
   title: "GHQ",
   description: "Play GHQ online, learn to play, and join the community.",
+  viewport: {
+    width: "device-width",
+    initialScale: 1,
+    maximumScale: 1,
+    userScalable: false,
+  },
   openGraph: {
     title: "GHQ",
     siteName: "GHQ",


### PR DESCRIPTION
fixes #260 -- videos of the old problem linked in that thread.

AI explanation of edits:

> ## **🏗️ How This Game Board Works**
> 
> In this GHQ game, the board is made up of 64 squares (8x8 grid), just like chess. Each square is a `<div>` element with special data attributes that tell the game which square it is:
> 
> ```html
> <div data-row-index="3" data-col-index="4">
>   <!-- This is square at row 3, column 4 -->
>   <img src="piece.png" /> <!-- The game piece image -->
> </div>
> ```
> 
> When you tap a square, the code needs to figure out "which square did they tap?" by looking at these data attributes.
> 
> ## **🐛 The Specific Bugs We Fixed**
> 
> ### **Bug `#1`: Data Attribute Mismatch**
> ```javascript
> // The HTML had this:
> <div data-row-index="3" data-col-index="4">
> 
> // But the JavaScript was looking for this:
> const { rowIndex, colIndex } = element.dataset; // Looking for camelCase
> ```
> 
> **Problem**: HTML uses kebab-case (`data-row-index`) but JavaScript was only looking for camelCase (`rowIndex`). Sometimes it worked, sometimes it didn't.
> 
> **Fix**: Check for both formats:
> ```javascript
> const rowIndex = el.dataset.rowIndex || el.dataset['row-index'];
> const colIndex = el.dataset.colIndex || el.dataset['col-index'];
> ```
> 
> ### **Bug `#2`: Wrong Coordinate System**
> ```javascript
> // OLD - Wrong way:
> const touchedElement = document.elementFromPoint(
>   touch.pageX,  // ❌ Relative to entire document
>   touch.pageY   // ❌ Includes scroll position
> );
> 
> // NEW - Correct way:
> const touchedElement = document.elementFromPoint(
>   touch.clientX,  // ✅ Relative to viewport
>   touch.clientY   // ✅ Ignores scroll position
> );
> ```
> 
> **Problem**: `pageX/pageY` includes the scroll position and is relative to the entire document. On mobile, this gets confusing with different screen sizes and zoom levels.
> 
> **Fix**: Use `clientX/clientY` which is relative to what you can see on screen (the viewport).
> 
> ### **Bug `#3`: Tapping on Child Elements**
> ```html
> <div data-row-index="3" data-col-index="4">  <!-- The square -->
>   <img src="piece.png" />  <!-- The piece image inside -->
> </div>
> ```
> 
> **Problem**: When users tap on a game piece, they're actually tapping the `<img>` element, not the square `<div>`. The `<img>` doesn't have the coordinate data attributes.
> 
> **Fix**: If the tapped element doesn't have coordinates, walk up the family tree to find a parent that does:
> ```javascript
> let attempts = 0;
> while (touchedElement && attempts < 10) {
>   const coordinate = getCoordinateFromElement(touchedElement);
>   if (coordinate) return coordinate; // Found it!
>   touchedElement = touchedElement.parentElement; // Check parent
>   attempts++;
> }
> ```
> 
> ### **Bug `#4`: Browser Interference**
> **Problem**: Mobile browsers have built-in behaviors like:
> - Scrolling when you drag
> - Zooming when you double-tap
> - Context menus on long press
> 
> These interfere with game interactions.
> 
> **Fix**: Tell the browser "don't do your normal mobile stuff":
> ```javascript
> e.preventDefault(); // Stop default touch behaviors
> // And in CSS:
> style={{ touchAction: "none" }}
> ```
> 
> ### **Bug `#5`: Inconsistent Screen Scaling**
> **Problem**: Different phones scale web pages differently. Without proper viewport settings, a 300px wide board might appear as 600px on some phones and 150px on others.
> 
> **Fix**: Add proper viewport meta tag:
> ```javascript
> viewport: {
>   width: "device-width",     // Use actual device width
>   initialScale: 1,           // Don't zoom in/out by default
>   maximumScale: 1,           // Prevent accidental zooming
>   userScalable: false,       // Disable pinch-to-zoom
> }
> ```
> 
> ## **🎯 Why These Fixes Work**
> 
> 1. **More reliable coordinate detection** - We now find the right square even if you tap slightly off-center or on a piece image
> 2. **Consistent across screen sizes** - Using viewport-relative coordinates works the same on all devices
> 3. **No browser interference** - Preventing default behaviors stops scrolling and zooming from messing up gameplay
> 4. **Proper scaling** - Viewport settings ensure the game looks the same size on all phones

This may have been overkill. It does seem to work though.